### PR TITLE
Feature: Switch OPENAI's API URL

### DIFF
--- a/R/chatgpt-package.R
+++ b/R/chatgpt-package.R
@@ -11,3 +11,5 @@ assign(
   list(list(role = "system", content = "You are a helpful assistant.")),
   envir = .state
 )
+
+api_url <- Sys.getenv("OPENAI_API_URL", "https://api.openai.com/v1")

--- a/R/gpt_get_completions.R
+++ b/R/gpt_get_completions.R
@@ -62,7 +62,7 @@ gpt_get_completions <- function(prompt, openai_api_key = Sys.getenv("OPENAI_API_
   keep_querying <- TRUE
   while (keep_querying) {
     post_res <- POST(
-      "https://api.openai.com/v1/chat/completions",
+      paste0(api_url, "/chat/completions"),
       add_headers("Authorization" = paste("Bearer", openai_api_key)),
       content_type_json(),
       body = toJSON(c(params, list(messages = messages)), auto_unbox = TRUE),

--- a/README.Rmd
+++ b/README.Rmd
@@ -139,6 +139,11 @@ cat(chatgpt::explain_code("for (i in 1:10) {\n  print(i ** 2)\n}"))
 In order to run ChatGPT queries behind a proxy, set the `OPENAI_PROXY` environment variable with a valid `IP:PORT` proxy.
 E.g., `Sys.setenv("OPENAI_PROXY" = "81.94.255.13:8080")`.
 
+### Switch OPENAI's API URL
+
+To replace the default OPENAI's API URL (`"https://api.openai.com/v1"`), you can set the `OPENAI_API_URL` environment variable with the URL you need to use.
+E.g., `Sys.setenv("OPENAI_API_URL" = "https://api.chatanywhere.com.cn")`.
+
 ### ChatGPT Model Tweaks
 
 ChatGPT model parameters can be tweaked by using environment variables.

--- a/README.md
+++ b/README.md
@@ -342,6 +342,11 @@ In order to run ChatGPT queries behind a proxy, set the `OPENAI_PROXY`
 environment variable with a valid `IP:PORT` proxy. E.g.,
 `Sys.setenv("OPENAI_PROXY" = "81.94.255.13:8080")`.
 
+### Switch OPENAI's API URL
+
+To replace the default OPENAI's API URL (`"https://api.openai.com/v1"`), you can set the `OPENAI_API_URL` environment variable with the URL you need to use.
+E.g., `Sys.setenv("OPENAI_API_URL" = "https://api.chatanywhere.com.cn")`.
+
 ### ChatGPT Model Tweaks
 
 ChatGPT model parameters can be tweaked by using environment variables.


### PR DESCRIPTION
As requested in https://github.com/jcrodriguez1989/chatgpt/issues/48 , we need to be able to allow switching OPENAI's API URL.
This is now possible by setting the `OPENAI_API_URL` env variable.